### PR TITLE
Adding a reference to the joinup maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,54 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>ec.nbb.demetra</groupId>
-    <artifactId>webservice-parent</artifactId>
-    <version>0.0.1</version>
-    <packaging>pom</packaging>
-    <name>JDemetra+ Web Service</name>
-    <modules>
-        <module>ws-commons</module>
-        <module>demetra-webapp</module>
-        <module>demetra-webapp-standalone</module>
-    </modules>
-  
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ws-version>0.0.1</ws-version>
-        <junit-version>4.12</junit-version>
-        <version.jersey>2.21</version.jersey>
-        <swagger.version>1.5.9</swagger.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-  
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit-version}</version>
-                <scope>test</scope>
-            </dependency>
-        
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-jackson</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-        
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-jaxb</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            
-            <!-- Swagger -->
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-jersey2-jaxrs</artifactId>
-                <version>${swagger.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>ec.nbb.demetra</groupId>
+	<artifactId>webservice-parent</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+	<name>JDemetra+ Web Service</name>
+	<modules>
+		<module>ws-commons</module>
+		<module>demetra-webapp</module>
+		<module>demetra-webapp-standalone</module>
+	</modules>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<ws-version>0.0.1</ws-version>
+		<junit-version>4.12</junit-version>
+		<version.jersey>2.21</version.jersey>
+		<swagger.version>1.5.9</swagger.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>joinup-snapshots</id>
+			<url>https://joinup.ec.europa.eu/nexus/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>joinup-releases</id>
+			<url>https://joinup.ec.europa.eu/nexus/content/repositories/releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>${junit-version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.glassfish.jersey.media</groupId>
+				<artifactId>jersey-media-json-jackson</artifactId>
+				<version>${version.jersey}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.glassfish.jersey.media</groupId>
+				<artifactId>jersey-media-jaxb</artifactId>
+				<version>${version.jersey}</version>
+			</dependency>
+
+			<!-- Swagger -->
+			<dependency>
+				<groupId>io.swagger</groupId>
+				<artifactId>swagger-jersey2-jaxrs</artifactId>
+				<version>${swagger.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>


### PR DESCRIPTION
Hi everyone

If one runs a mvn install on the whole maven project this error appears :

```
[ERROR]   The project ec.nbb.demetra:webapp:0.0.1 (D:\arkn1q\Mes Documents\eclipse_workspace\jdemetra-ws\demetra-webapp\pom.xml) has 3 errors
[ERROR]     Non-resolvable import POM: Failure to find eu.europa.ec.joinup.sat:demetra-parent:pom:2.2.0-SNAPSHOT in http://integration-continue.insee.fr/artifactory/repo was cached in the local reposi
tory, resolution will not be reattempted until the update interval of insee-snapshots has elapsed or updates are forced @ line 27, column 25 -> [Help 2]
[ERROR]     'dependencies.dependency.version' for eu.europa.ec.joinup.sat:demetra-tstoolkit:jar is missing. @ line 38, column 21
[ERROR]     'dependencies.dependency.version' for eu.europa.ec.joinup.sat:demetra-tss:jar is missing. @ line 42, column 21
```

Indeed, default maven configuration does not include a reference to the joinup maven repository.

A simple solution could be to add the reference to this repo in the pom.xml of the project, hence this PR.