### PR TITLE
Adding a CORS filter class compatible with the standalone service

### DIFF
--- a/demetra-webapp-standalone/src/main/java/ec/nbb/demetra/standalone/Main.java
+++ b/demetra-webapp-standalone/src/main/java/ec/nbb/demetra/standalone/Main.java
@@ -17,7 +17,9 @@
 package ec.nbb.demetra.standalone;
 
 import java.io.IOException;
+
 import javax.ws.rs.core.UriBuilder;
+
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -42,7 +44,8 @@ public class Main {
                 .register(io.swagger.jersey.listing.ApiListingResourceJSON.class)
                 .register(io.swagger.jaxrs.listing.SwaggerSerializers.class)
                 .register(ec.nbb.ws.json.JacksonJsonProvider.class)
-                .register(org.glassfish.jersey.jackson.JacksonFeature.class);
+                .register(org.glassfish.jersey.jackson.JacksonFeature.class)
+                .register(ec.nbb.ws.filters.CORSFilter.class);
 
         UriBuilder builder = UriBuilder.fromUri(BASE_URI).port(port);
 

--- a/ws-commons/src/main/java/ec/nbb/ws/filters/CORSFilter.java
+++ b/ws-commons/src/main/java/ec/nbb/ws/filters/CORSFilter.java
@@ -1,0 +1,23 @@
+package ec.nbb.ws.filters;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * CORS Filter 
+ * */
+public class CORSFilter implements ContainerResponseFilter {
+
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+
+        MultivaluedMap<String, Object> headers = responseContext.getHeaders();
+        headers.add("Access-Control-Allow-Origin", "*");        
+        headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS");            
+        headers.add("Access-Control-Allow-Headers", "X-Requested-With, Content-Type");
+    }
+
+}


### PR DESCRIPTION
Hi

The already available [CORS filter](https://github.com/nbbrd/jdemetra-ws/blob/master/ws-commons/src/main/java/ec/nbb/ws/filters/HTML5CorsFilter.java) doesn't seem to work with the ResourceConfig class used in the startup of the standalone service.

I propose another filter implementing the JAX-RS ContainerResponseFilter interface (my original code being enhanced by @BoogalooJB).

Best regards
R